### PR TITLE
Add conversation mode to translation command

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,8 @@
     "python.analysis.extraPaths": [
         "src\\bot",
         "src\\msu"
-    ]
+    ],
+    "terminal.integrated.env.windows": {
+        "PATH": "${env:PATH}${workspaceFolder}\\scripts"
+    }
 }

--- a/changelogs/unreleased/10-Add-conversation-mode-to-translation-command.yml
+++ b/changelogs/unreleased/10-Add-conversation-mode-to-translation-command.yml
@@ -1,0 +1,4 @@
+---
+title: Add conversation mode to translation command
+pull_request: 10
+type: features

--- a/src/bot/MGCert.py
+++ b/src/bot/MGCert.py
@@ -1,4 +1,5 @@
 import asyncio
+import discord
 from discord.ext import commands
 from functools import wraps
 import logging
@@ -74,7 +75,12 @@ class MGCertificate:
                     commandPrefix=CONFIG.commandPrefix)
 
             @wraps(func)
-            async def outerfunc(ctx, *args, **kwargs):
+            async def outerfunc(*args, **kwargs):
+                if isinstance(args[0], commands.context.Context):
+                    ctx = args[0]
+                else:
+                    ctx = args[1]
+
                 req_user = str(ctx.author)
 
                 if self.getUserLevel(req_user) > level:
@@ -89,6 +95,6 @@ class MGCertificate:
                         req_user, ctx.command.name, Level.get_description(level)))
                     raise Exception('Untrusted user')
 
-                return await func(ctx, *args, **kwargs)
+                return await func(*args, **kwargs)
             return outerfunc
         return deco

--- a/src/bot/app.py
+++ b/src/bot/app.py
@@ -62,7 +62,7 @@ async def on_ready():
 
 
 @bot.event
-async def on_message(message):
+async def on_message(message: discord.Message):
     if message.author == bot.user:
         return
 

--- a/src/bot/core/translate.py
+++ b/src/bot/core/translate.py
@@ -3,91 +3,167 @@ import discord
 import requests
 from .utils.config import CONFIG
 from langdetect import detect
+from distutils.util import strtobool
+from .utils import listener
 
 
 def setup(bot: commands.Bot):
-    @commands.command(aliases=['trans'])
-    @bot.MGCert.verify(2)
-    async def translate(ctx: commands.Context, msg, targetLang='en'):
-        """
-        Command that translates sentence entered to desired language 
-        Language list:
-                        Korean	       kr
-                        English	       en
-                        Japanese	   jp
-                        Chinese	       cn
-                        Vietnamese	   vi
-                        Inodonesian	   id
-                        Arabic	       ar
-                        Bengali	       bn
-                        German	       de
-                        Spanish	       es
-                        French	       fr
-                        Hindi	       hi
-                        Italian	       it
-                        Malay	       ms
-                        Dutch	       nl
-                        Portuguese	   pt
-                        Russian	       ru
-                        Thai	       th
-                        Turkish	       tr
+    class Translate(commands.Cog):
 
-        {commandPrefix}translate "What does it mean in English?" english
-        {commandPrefix}translate "What does it mean in English?" en
-        """
-        channel = ctx.message.channel
-        srcLang = detect(msg)
-        languages = {"korean": "kr",
-                     "english": "en",
-                     "japanese": "jp",
-                     "chinese": "cn",
-                     "vietnamese": "vi",
-                     "indonesian": "id",
-                     "arabic": "ar",
-                     "bengali": "bn",
-                     "german": "de",
-                     "spanish": "es",
-                     "french": "fr",
-                     "hindi": "hi",
-                     "italian": "it",
-                     "malay": "ms",
-                     "dutch": "nl",
-                     "portuguese": "pt",
-                     "russian": "ru",
-                     "thai": "th",
-                     "turkish": "tr"}
+        def __init__(self):
+            self.conversation = False
+            self.target = {'en'}
+            self.languages = {"korean": "kr",
+                              "english": "en",
+                              "japanese": "jp",
+                              "chinese": "cn",
+                              "vietnamese": "vi",
+                              "indonesian": "id",
+                              "arabic": "ar",
+                              "bengali": "bn",
+                              "german": "de",
+                              "spanish": "es",
+                              "french": "fr",
+                              "hindi": "hi",
+                              "italian": "it",
+                              "malay": "ms",
+                              "dutch": "nl",
+                              "portuguese": "pt",
+                              "russian": "ru",
+                              "thai": "th",
+                              "turkish": "tr"}
 
-        langDetectDict = {
-            "ko": "kr",
-            "ja": "jp",
-            "zh": "cn", }
+        @commands.Cog.listener()
+        @listener.on_message(bot)
+        async def on_message(self, message: discord.Message):
+            if (not self.conversation):
+                return
+            print(message.content)
+            ctx = await bot.get_context(message)
+            _, result = await self._trans(ctx, message.content, self.target)
+            if len(result) > 1:
+                await ctx.send('\n'.join([f"{k.upper()}: {v}" for k, v in result.items()]))
+            else:
+                await ctx.send('\n'.join([f"{v}" for _, v in result.items()]))
 
-        if srcLang in langDetectDict:
-            srcLang = langDetectDict[srcLang]
+        @commands.command(aliases=['trans'])
+        @bot.MGCert.verify(2)
+        async def translate(self, ctx: commands.Context, *args):
+            """
+            Command that translates sentence entered to desired language 
+            Language list:
+                            Korean	       kr
+                            English	       en
+                            Japanese	   jp
+                            Chinese	       cn
+                            Vietnamese	   vi
+                            Inodonesian	   id
+                            Arabic	       ar
+                            Bengali	       bn
+                            German	       de
+                            Spanish	       es
+                            French	       fr
+                            Hindi	       hi
+                            Italian	       it
+                            Malay	       ms
+                            Dutch	       nl
+                            Portuguese	   pt
+                            Russian	       ru
+                            Thai	       th
+                            Turkish	       tr
 
-        if not srcLang in languages.values():
-            await channel.send(embed=bot.replyformat.get(ctx, 'Translation Fail: Input Language Detection Failed', 'Language detected is not supported. \n ** Detected language: ' + srcLang + ' **\nuse //help translate to find supported languages'))
-            raise commands.CommandError(
-                "srcLanguage detected is not supported")
+            {commandPrefix}translate "What does it mean in English?" english
+            {commandPrefix}translate "What does it mean in English?" en
 
-        if targetLang.lower() in languages:
-            targetLang = languages[targetLang.lower()]
+            * Conversation Mode (beta)
+            --conversation <true_or_false>
+              You can also use <t_or_f>, <y_or_n> and <on_or_off>.
+            -- target <languages>
+              You can either give multiple languages separated by comma (,).
 
-        elif not targetLang in languages.values():
-            await channel.send(embed=bot.replyformat.get(ctx, 'Translation Fail: Target language not existing', 'Cannot find target language inputted'))
-            raise commands.CommandError("targetlang not identified")
+            Activate
+            .translate --conversation true --target en
+            .translate --conversation true --target en,jp,kr
 
-        headers = {
-            'Authorization': 'KakaoAK ' + CONFIG.kakaoToken
-        }
-        params = {
-            'query': msg,
-            'src_lang': srcLang,
-            'target_lang': targetLang
-        }
-        response = requests.get(
-            'https://kapi.kakao.com/v1/translation/translate', headers=headers, params=params)
+            Deactivate
+            .translate --conversation false
+            """
+            if '--conversation' in args:
+                try:
+                    self.conversation = strtobool(
+                        args[args.index('--conversation') + 1])
+                except ValueError as e:
+                    await ctx.send(embed=bot.replyformat.get(
+                        ctx, 'Usage Error', str(e)))
+                if '--target' in args:
+                    targetLangs = set(
+                        args[args.index('--target') + 1].split(','))
+                    self.target = await self._convert_langs(ctx, targetLangs)
+                if self.conversation:
+                    await ctx.send(embed=bot.replyformat.get(
+                        ctx, 'Start Conversation Mode', f'All messages are automatically translated to {", ".join([x.upper() for x in sorted(self.target)])}.'))
+                else:
+                    await ctx.send(embed=bot.replyformat.get(
+                        ctx, 'Exit Conversation Mode'))
+                return
+            else:
+                msg = args[0]
+                targetLangs = {args[1]} if len(args) > 1 else self.target
 
-        await channel.send(embed=bot.replyformat.get(ctx, 'Translation Successful: ' + srcLang + ' => ' + targetLang, msg + '\n\n' + response.json()['translated_text'][0][0]))
+            srcLang, result = await self._trans(ctx, msg, await self._convert_langs(ctx, targetLangs))
+            for t, r in result.items():
+                await ctx.send(embed=bot.replyformat.get(ctx, 'Translation Successful ' + srcLang + ' => ' + t, msg + '\n\n' + r))
 
-    bot.add_command(translate)
+        async def _convert_langs(self, ctx, langs:  set):
+            short_langs = {t for t in langs if t.lower()
+                           in self.languages}
+            langs = (
+                langs - short_langs) | {self.languages[t] for t in short_langs}
+            invalid_langs = {t for t in langs if not (
+                t in self.languages.values())}
+            langs -= invalid_langs
+
+            if len(langs) == 0:
+                await ctx.send(embed=bot.replyformat.get(ctx, f'Translation Fail: {", ".join(invalid_langs)}', 'Cannot find target language(s) inputted'))
+                raise commands.CommandError("targetlang not identified")
+            elif len(invalid_langs) > 0:
+                await ctx.send(embed=bot.replyformat.get(ctx, f'Translation Warning: {", ".join(invalid_langs)}', 'Cannot find target language(s) inputted'))
+
+            return langs
+
+        async def _trans(self, ctx, msg, targetLangs: set):
+            channel = ctx.message.channel
+            srcLang = detect(msg)
+
+            langDetectDict = {
+                "ko": "kr",
+                "ja": "jp",
+                "zh": "cn", }
+
+            if srcLang in langDetectDict:
+                srcLang = langDetectDict[srcLang]
+
+            if not srcLang in self.languages.values():
+                await channel.send(embed=bot.replyformat.get(ctx, 'Translation Fail: Input Language Detection Failed', 'Language detected is not supported. \n ** Detected language: ' + srcLang + ' **\nuse //help translate to find supported languages'))
+                raise commands.CommandError(
+                    "srcLanguage detected is not supported")
+            
+            result = {}
+            headers = {
+                'Authorization': 'KakaoAK ' + CONFIG.kakaoToken
+            }
+
+            for t in targetLangs:
+                if t != srcLang:
+                    params = {
+                        'query': msg,
+                        'src_lang': srcLang,
+                        'target_lang': t
+                    }
+                    response = requests.get(
+                        'https://kapi.kakao.com/v1/translation/translate', headers=headers, params=params)
+                    result[t] = response.json()['translated_text'][0][0]
+
+            return srcLang, result
+
+    bot.add_cog(Translate())

--- a/src/bot/core/utils/listener.py
+++ b/src/bot/core/utils/listener.py
@@ -1,0 +1,29 @@
+from functools import wraps
+
+from discord import message
+from .config import CONFIG
+import discord
+
+
+def on_message(bot):
+    def deco(func):
+        @wraps(func)
+        async def outerfunc(*args, **kwargs):
+            if isinstance(args[0], discord.Message):
+                message = args[0]
+            else:
+                message = args[1]
+
+            if message.author == bot.user:
+                return
+
+            if (message.channel.type.value == 1) and (CONFIG.disabledPrivateChannel):
+                return
+            ctx = await bot.get_context(message)
+
+            if ctx.valid:
+                return
+
+            return await func(*args, **kwargs)
+        return outerfunc
+    return deco


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request
* Add conversation mode to translation command

## PR Checklist
* [ ] Closes #xxx

### Testing
* [x] [Tested in packaged application](https://gitlab.com/mgylabs/mulgyeol-mkbot/-/wikis/home#testing-in-packaged-application)

### Dependency Changes
* [ ] Labeled as `dependencies`
* [ ] [Validated hook files](https://gitlab.com/mgylabs/mulgyeol-mkbot/-/wikis/home#pyinstaller)

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments
```
* Conversation Mode (beta)
       --conversation <true_or_false>
           You can also use <t_or_f>, <y_or_n> and <on_or_off>.
       -- target <languages>
           You can either give multiple languages separated by comma (,).

       Activate
         .translate --conversation true --target en
         .translate --conversation true --target en,jp,kr

       Deactivate
         .translate --conversation false
```